### PR TITLE
Pass cli options to deploy call in e2e test.

### DIFF
--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -39,7 +39,7 @@ def test_deployment(tmp_project, cli_options, request):
         request.config.cache.set("app_name", app_name)
 
     # Run simple_deploy against the test project.
-    it_utils.run_simple_deploy(python_cmd, "fly_io", cli_options.automate_all)
+    it_utils.run_simple_deploy(python_cmd, "fly_io", cli_options.automate_all, cli_options.plugin_args_string)
 
     # If testing Pipenv, lock after adding new packages.
     if cli_options.pkg_manager == "pipenv":


### PR DESCRIPTION
Support custom CLI args when running e2e tests.

Example call:

```sh
$ pytest tests/e2e_tests --plugin dsd_flyio -s --plugin-args-string "--vm-size shared-cpu-2x"
```