### PR TITLE
Set `SECRET_KEY` env variable on Fly.io

### DIFF
--- a/dsd_flyio/platform_deployer.py
+++ b/dsd_flyio/platform_deployer.py
@@ -11,6 +11,8 @@ Notes:
 import sys, os, re, json
 from pathlib import Path
 
+from django.core.management.utils import get_random_secret_key
+from django.utils.crypto import get_random_string
 from django.utils.safestring import mark_safe
 
 import requests
@@ -100,6 +102,7 @@ class PlatformDeployer:
 
         self._set_on_flyio()
         self._set_debug()
+        self._set_secret_key()
 
     def _set_on_flyio(self):
         """Set a secret, ON_FLYIO. This is used in settings.py to apply
@@ -116,6 +119,23 @@ class PlatformDeployer:
         msg = "Setting DEBUG secret..."
         plugin_utils.write_output(msg)
         self._set_secret("DEBUG", "DEBUG=FALSE")
+
+    def _set_secret_key(self):
+        """Set a secret, SECRET_KEY. This is used in settings.py as the 
+        secret key for the Django project. Keep it confidential to 
+        prevent security vulnerabilities.
+        """
+        # Generate a new key.
+        if dsd_config.on_windows:
+            # Non-alphanumeric keys have been problematic on Windows.
+            new_secret_key = get_random_string(
+                length=50, allowed_chars="abcdefghijklmnopqrstuvwxyz0123456789"
+            )
+        else:
+            new_secret_key = get_random_secret_key()
+        msg = "Setting SECRET_KEY secret..."
+        plugin_utils.write_output(msg)
+        self._set_secret("SECRET_KEY", f"SECRET_KEY={new_secret_key}", skip_logging=True)
 
     def _add_dockerfile(self):
         """Add a minimal dockerfile.
@@ -228,7 +248,7 @@ class PlatformDeployer:
             msg = platform_msgs.success_msg(log_output=dsd_config.log_output)
         plugin_utils.write_output(msg)
 
-    def _set_secret(self, needle, secret):
+    def _set_secret(self, needle, secret, skip_logging=False):
         """Set a secret on Fly, if it's not already set.
 
         DEV: Do we need to say that it's already set, and get confirmation to change
@@ -255,11 +275,14 @@ class PlatformDeployer:
             return
 
         cmd = f"fly secrets set -a {self.deployed_project_name} {secret}"
-        output_obj = plugin_utils.run_quick_command(cmd)
+        output_obj = plugin_utils.run_quick_command(cmd, skip_logging=skip_logging)
         output_str = output_obj.stdout.decode()
         plugin_utils.write_output(output_str)
 
-        msg = f"  Set secret: {secret}"
+        if skip_logging:
+            msg = f"  Set secret: {needle}"
+        else:
+            msg = f"  Set secret: {secret}"
         plugin_utils.write_output(msg)
 
     def _build_dockerignore(self):

--- a/dsd_flyio/templates/settings.py
+++ b/dsd_flyio/templates/settings.py
@@ -26,6 +26,9 @@ if os.environ.get("ON_FLYIO"):
     #   here may not.
     import dj_database_url
 
+    # Always use secret key from Fly.io environment variable.
+    SECRET_KEY = os.getenv("SECRET_KEY")
+
     # Use secret, if set, to update DEBUG value.
     if os.environ.get("DEBUG") == "FALSE":
         DEBUG = False

--- a/tests/integration_tests/reference_files/settings.py
+++ b/tests/integration_tests/reference_files/settings.py
@@ -159,6 +159,9 @@ if os.environ.get("ON_FLYIO"):
     #   here may not.
     import dj_database_url
 
+    # Always use secret key from Fly.io environment variable.
+    SECRET_KEY = os.getenv("SECRET_KEY")
+
     # Use secret, if set, to update DEBUG value.
     if os.environ.get("DEBUG") == "FALSE":
         DEBUG = False


### PR DESCRIPTION
**Goals / What does this do?**

* Set `SECRET_KEY` env variable on Fly.io during deployment.
* Use `SECRET_KEY` from `os.environ` when running Django app on Fly.io.

**Context / Why?**

Before, our Fly.io deployment would use the `SECRET_KEY` printed / hard-coded in `settings.py` which is a bad (security) practice.

This implementation — including the "Non-alphanumeric keys have been problematic on Windows" part — is almost 100% copy & paste from the soon-to-be-archived *Heroku plugin*: https://github.com/django-simple-deploy/dsd-heroku/blob/main/dsd_heroku/platform_deployer.py#L496-L512.

See https://github.com/django-simple-deploy/dsd-flyio/issues/25#issuecomment-3992637808.